### PR TITLE
Managing multiple contexts

### DIFF
--- a/Contact+CoreDataProperties.swift
+++ b/Contact+CoreDataProperties.swift
@@ -18,6 +18,7 @@ extension Contact {
     @NSManaged public var firstName: String?
     @NSManaged public var lastName: String?
     @NSManaged public var conversations: NSSet?
+    @NSManaged public var messages: NSSet?
 
 }
 
@@ -35,5 +36,22 @@ extension Contact {
 
     @objc(removeConversations:)
     @NSManaged public func removeFromConversations(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for messages
+extension Contact {
+
+    @objc(addMessagesObject:)
+    @NSManaged public func addToMessages(_ value: Message)
+
+    @objc(removeMessagesObject:)
+    @NSManaged public func removeFromMessages(_ value: Message)
+
+    @objc(addMessages:)
+    @NSManaged public func addToMessages(_ values: NSSet)
+
+    @objc(removeMessages:)
+    @NSManaged public func removeFromMessages(_ values: NSSet)
 
 }

--- a/Inbox.xcodeproj/project.pbxproj
+++ b/Inbox.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		FC1547621DED57CC009037ED /* Contact+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC1547601DED57CC009037ED /* Contact+CoreDataClass.swift */; };
+		FC6E9A0C1DEE9FDA006EDFE2 /* Contact+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6E9A0A1DEE9FDA006EDFE2 /* Contact+CoreDataProperties.swift */; };
+		FC6E9A0D1DEE9FDA006EDFE2 /* Message+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6E9A0B1DEE9FDA006EDFE2 /* Message+CoreDataProperties.swift */; };
 		FC85E4381DE3DB48004AE574 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E4371DE3DB48004AE574 /* AppDelegate.swift */; };
 		FC85E43A1DE3DB48004AE574 /* MessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E4391DE3DB48004AE574 /* MessageViewController.swift */; };
 		FC85E43D1DE3DB48004AE574 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC85E43B1DE3DB48004AE574 /* Main.storyboard */; };
@@ -20,19 +22,19 @@
 		FC85E45E1DE7B2F8004AE574 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FC85E45C1DE7B2F8004AE574 /* Model.xcdatamodeld */; };
 		FC85E4691DECA4AE004AE574 /* Conversation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E4651DECA4AE004AE574 /* Conversation+CoreDataClass.swift */; };
 		FC85E46D1DECA4F3004AE574 /* Message+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E46B1DECA4F3004AE574 /* Message+CoreDataClass.swift */; };
-		FC85E46E1DECA4F3004AE574 /* Message+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E46C1DECA4F3004AE574 /* Message+CoreDataProperties.swift */; };
 		FC85E4701DECACDB004AE574 /* ConversationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E46F1DECACDB004AE574 /* ConversationCell.swift */; };
 		FC85E4721DECDB20004AE574 /* AllConversationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC85E4711DECDB20004AE574 /* AllConversationsViewController.swift */; };
 		FCDE7C0C1DED6D670049F1D0 /* NewConversationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C0B1DED6D670049F1D0 /* NewConversationViewController.swift */; };
 		FCDE7C0E1DEDDB0A0049F1D0 /* UITableViewFetchedResultsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C0D1DEDDB0A0049F1D0 /* UITableViewFetchedResultsDelegate.swift */; };
 		FCDE7C101DEDE7DD0049F1D0 /* UIViewController+SetupMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C0F1DEDE7DD0049F1D0 /* UIViewController+SetupMainView.swift */; };
 		FCDE7C171DEE28970049F1D0 /* Conversation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C151DEE28970049F1D0 /* Conversation+CoreDataProperties.swift */; };
-		FCDE7C181DEE28970049F1D0 /* Contact+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C161DEE28970049F1D0 /* Contact+CoreDataProperties.swift */; };
 		FCDE7C1B1DEE41C80049F1D0 /* ConversationBeganDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDE7C1A1DEE41C80049F1D0 /* ConversationBeganDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		FC1547601DED57CC009037ED /* Contact+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Contact+CoreDataClass.swift"; path = "../Contact+CoreDataClass.swift"; sourceTree = "<group>"; };
+		FC6E9A0A1DEE9FDA006EDFE2 /* Contact+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Contact+CoreDataProperties.swift"; path = "../Contact+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		FC6E9A0B1DEE9FDA006EDFE2 /* Message+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Message+CoreDataProperties.swift"; path = "../Message+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		FC85E4341DE3DB48004AE574 /* Inbox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Inbox.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC85E4371DE3DB48004AE574 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FC85E4391DE3DB48004AE574 /* MessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageViewController.swift; sourceTree = "<group>"; };
@@ -47,14 +49,12 @@
 		FC85E45D1DE7B2F8004AE574 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		FC85E4651DECA4AE004AE574 /* Conversation+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Conversation+CoreDataClass.swift"; path = "../Conversation+CoreDataClass.swift"; sourceTree = "<group>"; };
 		FC85E46B1DECA4F3004AE574 /* Message+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Message+CoreDataClass.swift"; path = "../Message+CoreDataClass.swift"; sourceTree = "<group>"; };
-		FC85E46C1DECA4F3004AE574 /* Message+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Message+CoreDataProperties.swift"; path = "../Message+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		FC85E46F1DECACDB004AE574 /* ConversationCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationCell.swift; sourceTree = "<group>"; };
 		FC85E4711DECDB20004AE574 /* AllConversationsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllConversationsViewController.swift; sourceTree = "<group>"; };
 		FCDE7C0B1DED6D670049F1D0 /* NewConversationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewConversationViewController.swift; sourceTree = "<group>"; };
 		FCDE7C0D1DEDDB0A0049F1D0 /* UITableViewFetchedResultsDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewFetchedResultsDelegate.swift; sourceTree = "<group>"; };
 		FCDE7C0F1DEDE7DD0049F1D0 /* UIViewController+SetupMainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+SetupMainView.swift"; sourceTree = "<group>"; };
 		FCDE7C151DEE28970049F1D0 /* Conversation+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Conversation+CoreDataProperties.swift"; path = "../Conversation+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		FCDE7C161DEE28970049F1D0 /* Contact+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Contact+CoreDataProperties.swift"; path = "../Contact+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		FCDE7C1A1DEE41C80049F1D0 /* ConversationBeganDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationBeganDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -116,12 +116,12 @@
 		FC85E44A1DE4B2CE004AE574 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				FCDE7C161DEE28970049F1D0 /* Contact+CoreDataProperties.swift */,
+				FC6E9A0A1DEE9FDA006EDFE2 /* Contact+CoreDataProperties.swift */,
 				FC1547601DED57CC009037ED /* Contact+CoreDataClass.swift */,
+				FC6E9A0B1DEE9FDA006EDFE2 /* Message+CoreDataProperties.swift */,
 				FC85E46B1DECA4F3004AE574 /* Message+CoreDataClass.swift */,
-				FC85E46C1DECA4F3004AE574 /* Message+CoreDataProperties.swift */,
-				FC85E4651DECA4AE004AE574 /* Conversation+CoreDataClass.swift */,
 				FCDE7C151DEE28970049F1D0 /* Conversation+CoreDataProperties.swift */,
+				FC85E4651DECA4AE004AE574 /* Conversation+CoreDataClass.swift */,
 				FC85E45C1DE7B2F8004AE574 /* Model.xcdatamodeld */,
 			);
 			name = Models;
@@ -236,7 +236,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC85E46E1DECA4F3004AE574 /* Message+CoreDataProperties.swift in Sources */,
 				FC85E4511DE4D1B7004AE574 /* BubbleImageView.swift in Sources */,
 				FCDE7C0E1DEDDB0A0049F1D0 /* UITableViewFetchedResultsDelegate.swift in Sources */,
 				FCDE7C0C1DED6D670049F1D0 /* NewConversationViewController.swift in Sources */,
@@ -248,13 +247,14 @@
 				FC85E4581DE6362A004AE574 /* UITableView+Scroll.swift in Sources */,
 				FCDE7C171DEE28970049F1D0 /* Conversation+CoreDataProperties.swift in Sources */,
 				FC1547621DED57CC009037ED /* Contact+CoreDataClass.swift in Sources */,
-				FCDE7C181DEE28970049F1D0 /* Contact+CoreDataProperties.swift in Sources */,
 				FC85E4721DECDB20004AE574 /* AllConversationsViewController.swift in Sources */,
+				FC6E9A0C1DEE9FDA006EDFE2 /* Contact+CoreDataProperties.swift in Sources */,
 				FC85E4701DECACDB004AE574 /* ConversationCell.swift in Sources */,
 				FC85E4691DECA4AE004AE574 /* Conversation+CoreDataClass.swift in Sources */,
 				FC85E4381DE3DB48004AE574 /* AppDelegate.swift in Sources */,
 				FC85E46D1DECA4F3004AE574 /* Message+CoreDataClass.swift in Sources */,
 				FCDE7C1B1DEE41C80049F1D0 /* ConversationBeganDelegate.swift in Sources */,
+				FC6E9A0D1DEE9FDA006EDFE2 /* Message+CoreDataProperties.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Inbox/AllConversationsViewController.swift
+++ b/Inbox/AllConversationsViewController.swift
@@ -101,6 +101,16 @@ extension AllConversationsViewController : UITableViewDelegate {
         return true
     }
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let convo = fetchedResultsController?.object(at: indexPath) else { return }
+        print(convo)
+        let vc = MessageViewController()
+        vc.conversation = convo
+        vc.context = context
+        self.navigationController?.pushViewController(vc, animated: true)
+        dismiss(animated: true, completion: nil)
+    }
+    
 }
 
 extension AllConversationsViewController : UITableViewDataSource {
@@ -119,10 +129,6 @@ extension AllConversationsViewController : UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
         configureCell(cell: cell, indexPath: indexPath)
         return cell
-    }
-    
-    private func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let convo = fetchedResultsController?.object(at: indexPath) else { return }
     }
     
 }

--- a/Inbox/AllConversationsViewController.swift
+++ b/Inbox/AllConversationsViewController.swift
@@ -75,7 +75,7 @@ class AllConversationsViewController: UIViewController, UITableViewFetchedResult
         let formatter = DateFormatter()
         formatter.dateFormat = "MM/DD/YY"
         cell.nameLabel.text = contact.fullName
-        cell.messageLabel.text = lastMessage.text
+        cell.messageLabel.text = text
         cell.dateLabel.text = formatter.string(from: timestamp as Date)
     }
     

--- a/Inbox/AllConversationsViewController.swift
+++ b/Inbox/AllConversationsViewController.swift
@@ -50,7 +50,9 @@ class AllConversationsViewController: UIViewController, UITableViewFetchedResult
     
     func newConvo() {
         let vc = NewConversationViewController()
-        vc.context = context
+        let newConverationContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        newConverationContext.parent = context
+        vc.context = newConverationContext
         vc.conversationStartedDelegate = self
         let nav = UINavigationController(rootViewController: vc)
         nav.navigationBar.barTintColor = UIColor.white

--- a/Inbox/AllConversationsViewController.swift
+++ b/Inbox/AllConversationsViewController.swift
@@ -69,12 +69,14 @@ class AllConversationsViewController: UIViewController, UITableViewFetchedResult
         
         let cell = cell as! ConversationCell
         guard let convo = fetchedResultsController?.object(at: indexPath) else { return } //not casting necessary b/c fetchResultsVC is generic
+        guard let contact = convo.participants?.anyObject() as? Contact else { return }
+        guard let lastMessage = convo.lastMessage, let timestamp = lastMessage.timestamp, let text = lastMessage.text else { return }
         
         let formatter = DateFormatter()
         formatter.dateFormat = "MM/DD/YY"
-        cell.nameLabel.text = "Mitta"
-        cell.messageLabel.text = "Hey!"
-        cell.dateLabel.text = formatter.string(from: Date())
+        cell.nameLabel.text = contact.fullName
+        cell.messageLabel.text = lastMessage.text
+        cell.dateLabel.text = formatter.string(from: timestamp as Date)
     }
     
     func conversationStarted(withConvo convo: Conversation, inContext: NSManagedObjectContext) {

--- a/Inbox/MessageViewController.swift
+++ b/Inbox/MessageViewController.swift
@@ -189,7 +189,6 @@ class MessageViewController: UIViewController {
         guard let context = context else { return }
         guard let message = NSEntityDescription.insertNewObject(forEntityName: "Message", into: context) as? Message else { return }
         message.text = text
-        message.incoming = false
         message.timestamp = NSDate()
         conversation?.lastMessageTime = message.timestamp
         do {
@@ -243,7 +242,7 @@ extension MessageViewController : UITableViewDataSource {
         let messages = getMessages(indexPath.section)
         let message = messages?[indexPath.row]
         cell.messageLabel.text = message?.text
-        cell.incoming(messageType: (message?.incoming)!)
+        cell.incoming(messageType: message!.isIncoming)
         
         cell.backgroundColor = UIColor.clear
         

--- a/Inbox/MessageViewController.swift
+++ b/Inbox/MessageViewController.swift
@@ -120,11 +120,26 @@ class MessageViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(MessageViewController.keyboardWillHide(notification:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
         
+        if let mainContext = context?.parent ?? context {
+            NotificationCenter.default.addObserver(self, selector: #selector(MessageViewController.contextUpdated(notification:)), name: NSNotification.Name.NSManagedObjectContextObjectsDidChange, object: mainContext)
+        }
+        
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         tableView.scrollToBottom()
+    }
+    
+    func contextUpdated(notification: Notification) {
+        guard let set = notification.userInfo![NSInsertedObjectsKey] as? NSSet else { return }
+        let objects = set.allObjects
+        for object in objects {
+            guard let message = object as? Message else {continue}
+            if message.conversation?.objectID == conversation?.objectID {
+                addMessage(message: message)
+            }
+        }
     }
     
     func keyboardWillShow(notification: Notification) {

--- a/Inbox/MessageViewController.swift
+++ b/Inbox/MessageViewController.swift
@@ -61,6 +61,7 @@ class MessageViewController: UIViewController {
             guard let context = context else { throw ErrorType.NoContext }
             let request : NSFetchRequest<Message> = NSFetchRequest.init(entityName: "Message")
             request.sortDescriptors = [NSSortDescriptor.init(key: "timestamp", ascending: false)]
+            request.predicate = NSPredicate(format: "conversation=%@", conversation)
             if let result = try self.context?.fetch(request) {
                 for message in result {
                     addMessage(message: message)

--- a/Inbox/MessageViewController.swift
+++ b/Inbox/MessageViewController.swift
@@ -190,6 +190,7 @@ class MessageViewController: UIViewController {
         guard let message = NSEntityDescription.insertNewObject(forEntityName: "Message", into: context) as? Message else { return }
         message.text = text
         message.timestamp = NSDate()
+        message.conversation = conversation
         conversation?.lastMessageTime = message.timestamp
         do {
             try context.save()

--- a/Inbox/MessageViewController.swift
+++ b/Inbox/MessageViewController.swift
@@ -191,6 +191,7 @@ class MessageViewController: UIViewController {
         message.text = text
         message.incoming = false
         message.timestamp = NSDate()
+        conversation?.lastMessageTime = message.timestamp
         do {
             try context.save()
         } catch let error as NSError {

--- a/Inbox/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Inbox/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -4,6 +4,7 @@
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="participants" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Message" inverseName="sender" inverseEntity="Message" syncable="YES"/>
     </entity>
     <entity name="Conversation" representedClassName=".Conversation" syncable="YES">
         <attribute name="lastMessageTime" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -11,13 +12,13 @@
         <relationship name="participants" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Contact" inverseName="conversations" inverseEntity="Contact" syncable="YES"/>
     </entity>
     <entity name="Message" representedClassName=".Message" syncable="YES">
-        <attribute name="incoming" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="conversation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Conversation" inverseName="message" inverseEntity="Conversation" syncable="YES"/>
+        <relationship name="sender" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Contact" inverseName="messages" inverseEntity="Contact" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Contact" positionX="-54" positionY="27" width="128" height="90"/>
+        <element name="Contact" positionX="-54" positionY="27" width="128" height="105"/>
         <element name="Conversation" positionX="-54" positionY="18" width="128" height="90"/>
         <element name="Message" positionX="-63" positionY="-18" width="128" height="105"/>
     </elements>

--- a/Message+CoreDataClass.swift
+++ b/Message+CoreDataClass.swift
@@ -13,12 +13,7 @@ import CoreData
 public class Message: NSManagedObject {
 
     var isIncoming : Bool {
-        get {
-            return incoming
-        }
-        set(incoming) {
-            self.incoming = incoming
-        }
+        return sender != nil
     }
     
 }

--- a/Message+CoreDataProperties.swift
+++ b/Message+CoreDataProperties.swift
@@ -2,7 +2,7 @@
 //  Message+CoreDataProperties.swift
 //  Inbox
 //
-//  Created by Mikael Teklehaimanot on 11/28/16.
+//  Created by Mikael Teklehaimanot on 11/29/16.
 //  Copyright © 2016 Mikael Teklehaimanot. All rights reserved.
 //
 
@@ -15,9 +15,9 @@ extension Message {
         return NSFetchRequest<Message>(entityName: "Message");
     }
 
-    @NSManaged public var incoming: Bool
     @NSManaged public var text: String?
     @NSManaged public var timestamp: NSDate?
     @NSManaged public var conversation: Conversation?
+    @NSManaged public var sender: Contact?
 
 }


### PR DESCRIPTION
added functionality for saving to temporary context when new chats are initiated to avoid redundancy from possibility of closing chat without sending message when initiated. Functionality handles temporary context by communicating with parent context to save data if needed